### PR TITLE
Make clip size more parametric on the glass holder

### DIFF
--- a/round_glass.scad
+++ b/round_glass.scad
@@ -43,7 +43,7 @@ module frame_glass() {
     cylinder(r=glass_radius-5, h=20, center=true, $fn=120);
     translate([0, 0, thickness-1])
       cylinder(r=glass_radius, h=glass_thickness, $fn=120);
-    for (x = [-18, 18]) {
+    for (x = [clip_width/2+8, -clip_width/2-8]) {
       translate([x, triangle_offset, 0]) #
         cylinder(r=m3_wide_radius, h=20, center=true, $fn=12);
     }


### PR DESCRIPTION
I have big clips (and 360mm extrusion, but that didn't matter). The mounting hole offsets were hardcoded. This makes them more parametric, and it looks like they stay put compared to your version.
