### PR TITLE
Improve pg35l positioning

### DIFF
--- a/pg35l_extruder.scad
+++ b/pg35l_extruder.scad
@@ -28,7 +28,7 @@ filament_squish = 0.0; // Distance the drive gear teeth press into the filament.
 // Make sure to set these, to reduce friction from twisting the filament, as well as ensure that the drive gear bearings actually rest against the drive gear.
 drive_gear_width = 12;
 drive_gear_id = 5;
-drive_gear_od = 13;
+drive_gear_od = 12.67;
 drive_gear_valley_od = 11; // Diameter of drive gear at the valley of the teeth.
 drive_gear_offset = drive_gear_valley_od/2+filament_dia/2-filament_squish;  // Was: 7
 


### PR DESCRIPTION
The pg35l extruder in Kossel looks great.  After printing one, it looked like it wouldn't work, though, due to two bugs:
(1) The two drive gear bearings didn't touch the drive gear.
(2) The filament wouldn't even touch the drive gear teeth without bending.

This series of commits makes the pg35l extruder scad more parametric, aligns the filament and bearings to the drive gear, and does a few minor tweaks.

I haven't printed the updated file (yet), but I've checked in the scad that the drive gear aligns as expected now.
